### PR TITLE
[2022/07/04] Main 컴포넌트 리팩토링 및 zustand 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-scripts": "5.0.1",
         "react-webcam": "^7.0.1",
         "styled-components": "^5.3.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.0.0-rc.1"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -17142,6 +17143,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18777,6 +18786,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0-rc.1.tgz",
+      "integrity": "sha512-qgcs7zLqBdHu0PuT3GW4WCIY5SgXdsv30GQMu9Qpp1BA2aS+sNS8l4x0hWuyEhjXkN+701aGWawhKDv6oWJAcw==",
+      "dependencies": {
+        "use-sync-external-store": "1.1.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -31032,6 +31064,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "requires": {}
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -32406,6 +32444,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "4.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.0.0-rc.1.tgz",
+      "integrity": "sha512-qgcs7zLqBdHu0PuT3GW4WCIY5SgXdsv30GQMu9Qpp1BA2aS+sNS8l4x0hWuyEhjXkN+701aGWawhKDv6oWJAcw==",
+      "requires": {
+        "use-sync-external-store": "1.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-scripts": "5.0.1",
     "react-webcam": "^7.0.1",
     "styled-components": "^5.3.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.0.0-rc.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,79 +1,16 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React from "react";
 import styled from "styled-components";
-import Webcam from "react-webcam";
-import { FaExchangeAlt } from "react-icons/fa";
-import { MdCallEnd } from "react-icons/md";
-import { BsCameraVideoFill, BsCameraVideoOffFill } from "react-icons/bs";
-import { AiTwotoneAudio, AiOutlineAudioMuted } from "react-icons/ai";
+
+import WebcamScreen from "./WebcamScreen";
+import Question from "./Question";
+import WebcamButton from "./WebcamButton";
 
 function Main() {
-  const [isMuted, setIsMuted] = useState(false);
-  const [isWebcamOpen, setIsWebcamOpen] = useState(true);
-  const [isMirrored, setIsMirrored] = useState(true);
-  const [isQuestionStarted, setIsQuestionStarted] = useState(false);
-  const navigate = useNavigate();
-
   return (
     <ContentBox>
-      <section>
-        {isWebcamOpen ? (
-          <Webcam
-            className="video"
-            height={"100%"}
-            width={"100%"}
-            audio={isMuted}
-            mirrored={isMirrored}
-          />
-        ) : (
-          <></>
-        )}
-      </section>
-      <nav>
-        <Icon
-          style={
-            isMuted
-              ? { backgroundColor: "#ea4335" }
-              : { backgroundColor: "#3c4145" }
-          }
-          onClick={() => setIsMuted(!isMuted)}
-        >
-          {isMuted ? <AiOutlineAudioMuted /> : <AiTwotoneAudio />}
-        </Icon>
-        <Icon
-          style={
-            !isWebcamOpen
-              ? { backgroundColor: "#ea4335" }
-              : { backgroundColor: "#3c4145" }
-          }
-          onClick={() => setIsWebcamOpen(!isWebcamOpen)}
-        >
-          {isWebcamOpen ? <BsCameraVideoFill /> : <BsCameraVideoOffFill />}
-        </Icon>
-        <Icon onClick={() => setIsMirrored(!isMirrored)}>
-          <FaExchangeAlt />
-        </Icon>
-        <Icon className="end" onClick={() => navigate(-1)}>
-          <MdCallEnd />
-        </Icon>
-      </nav>
-
-      {isWebcamOpen ? (
-        !isQuestionStarted ? (
-          <QuestionStartBox
-            onClick={() => setIsQuestionStarted(!isQuestionStarted)}
-          >
-            <div>질문시작</div>
-          </QuestionStartBox>
-        ) : (
-          <QuestionBox>
-            <div className="question">나는 지금 떨고있다</div>
-            <div className="time">3</div>
-          </QuestionBox>
-        )
-      ) : (
-        <></>
-      )}
+      <WebcamScreen />
+      <Question />
+      <WebcamButton />
     </ContentBox>
   );
 }
@@ -86,104 +23,6 @@ const ContentBox = styled.div`
   width: 100%;
   height: 100%;
   background-color: black;
-
-  section {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    background-color: #181717;
-  }
-
-  nav {
-    position: absolute;
-    bottom: 0;
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
-    width: 25%;
-    height: 10%;
-
-    .end {
-      width: 60px;
-      height: 40px;
-      padding: 8px 13px;
-      border-radius: 100px;
-      font-size: 25px;
-      background-color: #ea4335;
-    }
-  }
-`;
-
-const QuestionStartBox = styled.div`
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  bottom: 12%;
-  height: 10%;
-  width: 20%;
-  background-color: white;
-  font-size: 40px;
-  border-radius: 15px;
-
-  :hover {
-    cursor: pointer;
-    transform: scale(1.05);
-  }
-`;
-
-const QuestionBox = styled.div`
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  bottom: 12%;
-  height: 10%;
-  width: 40%;
-  background-color: white;
-  font-size: 40px;
-  border-radius: 15px;
-
-  .question {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 80%;
-  }
-
-  .time {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: #ea4335;
-    color: white;
-    font-size: 50px;
-    width: 70px;
-    height: 70px;
-    border-radius: 50%;
-    padding-top: 4px;
-  }
-`;
-
-const Icon = styled.button`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: #3c4145;
-  border: none;
-  height: 45px;
-  width: 45px;
-  font-size: 20px;
-  border-radius: 50%;
-  color: white;
-  cursor: pointer;
-  opacity: 0.9;
-
-  :hover {
-    opacity: 1;
-    transform: scale(1.03);
-  }
 `;
 
 export default Main;

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import useStore from "../zustand/store";
+
+function Question() {
+  const [isQuestionStarted, setIsQuestionStarted] = useState(false);
+  const { isWebcamOpen } = useStore();
+
+  return isWebcamOpen ? (
+    isQuestionStarted ? (
+      <QuestionBox>
+        <div className="question">나는 지금 떨고있다</div>
+        <div className="time">3</div>
+      </QuestionBox>
+    ) : (
+      <QuestionStartBox
+        onClick={() => setIsQuestionStarted(!isQuestionStarted)}
+      >
+        <div>질문시작</div>
+      </QuestionStartBox>
+    )
+  ) : (
+    <></>
+  );
+}
+
+const QuestionStartBox = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  bottom: 12%;
+  height: 10%;
+  width: 20%;
+  background-color: white;
+  font-size: 40px;
+  border-radius: 15px;
+
+  :hover {
+    cursor: pointer;
+    transform: scale(1.05);
+  }
+`;
+
+const QuestionBox = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  bottom: 12%;
+  height: 10%;
+  width: 40%;
+  background-color: white;
+  font-size: 40px;
+  border-radius: 15px;
+
+  .question {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 80%;
+  }
+
+  .time {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #ea4335;
+    color: white;
+    font-size: 50px;
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    padding-top: 4px;
+  }
+`;
+
+export default Question;

--- a/src/components/WebcamButton.jsx
+++ b/src/components/WebcamButton.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import useStore from "../zustand/store";
+
+import { FaExchangeAlt } from "react-icons/fa";
+import { MdCallEnd } from "react-icons/md";
+import { BsCameraVideoFill, BsCameraVideoOffFill } from "react-icons/bs";
+import { AiTwotoneAudio, AiOutlineAudioMuted } from "react-icons/ai";
+
+const WebcamButton = () => {
+  const navigate = useNavigate();
+  const { isMuted, isWebcamOpen } = useStore();
+
+  return (
+    <WebcamButtonLayout>
+      <Icon
+        style={
+          isMuted
+            ? { backgroundColor: "#ea4335" }
+            : { backgroundColor: "#3c4145" }
+        }
+        onClick={useStore((state) => state.toggleIsMuted)}
+      >
+        {isMuted ? <AiOutlineAudioMuted /> : <AiTwotoneAudio />}
+      </Icon>
+      <Icon
+        style={
+          !isWebcamOpen
+            ? { backgroundColor: "#ea4335" }
+            : { backgroundColor: "#3c4145" }
+        }
+        onClick={useStore((state) => state.toggleIsWebcamOpen)}
+      >
+        {isWebcamOpen ? <BsCameraVideoFill /> : <BsCameraVideoOffFill />}
+      </Icon>
+      <Icon onClick={useStore((state) => state.toggleIsMirrored)}>
+        <FaExchangeAlt />
+      </Icon>
+      <Icon className="end" onClick={() => navigate(-1)}>
+        <MdCallEnd />
+      </Icon>
+    </WebcamButtonLayout>
+  );
+};
+
+const WebcamButtonLayout = styled.nav`
+  position: absolute;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  width: 25%;
+  height: 10%;
+
+  .end {
+    width: 60px;
+    height: 40px;
+    padding: 8px 13px;
+    border-radius: 100px;
+    font-size: 25px;
+    background-color: #ea4335;
+  }
+`;
+
+const Icon = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #3c4145;
+  border: none;
+  height: 45px;
+  width: 45px;
+  font-size: 20px;
+  border-radius: 50%;
+  color: white;
+  cursor: pointer;
+  opacity: 0.9;
+
+  :hover {
+    opacity: 1;
+    transform: scale(1.03);
+  }
+`;
+
+export default WebcamButton;

--- a/src/components/WebcamScreen.jsx
+++ b/src/components/WebcamScreen.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "styled-components";
+import Webcam from "react-webcam";
+import useStore from "../zustand/store";
+
+function WebcamScreen() {
+  const { isWebcamOpen, isMuted, isMirrored } = useStore();
+
+  return (
+    <WebcamLayout>
+      {isWebcamOpen ? (
+        <Webcam
+          className="video"
+          height={"100%"}
+          width={"100%"}
+          audio={isMuted}
+          mirrored={isMirrored}
+        />
+      ) : (
+        <></>
+      )}
+    </WebcamLayout>
+  );
+}
+
+const WebcamLayout = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: #181717;
+`;
+
+export default WebcamScreen;

--- a/src/zustand/store.js
+++ b/src/zustand/store.js
@@ -1,0 +1,16 @@
+import create from "zustand";
+import { devtools } from "zustand/middleware";
+
+const store = (set) => ({
+  isMuted: false,
+  toggleIsMuted: () => set((state) => ({ isMuted: !state.isMuted })),
+  isWebcamOpen: true,
+  toggleIsWebcamOpen: () =>
+    set((state) => ({ isWebcamOpen: !state.isWebcamOpen })),
+  isMirrored: true,
+  toggleIsMirrored: () => set((state) => ({ isMirrored: !state.isMirrored })),
+});
+
+const useStore = create(devtools(store));
+
+export default useStore;


### PR DESCRIPTION
## 주제
Main 컴포넌트 리팩토링 및 zustand 적용

## 작업사항
- Main 컴포넌트 리팩토링
- WebcamScreen 컴포넌트 생성
- WebcamButton 컴포넌트 생성
- Question 컴포넌트 생성
- zustand 적용

### 변경사항
- useState -> zustand 상태관리
- Main 컴포넌트 코드 최소화

## 기타
- zustand 적용했을 경우 전역으로 상태관리하기가 아주 편해졌다. 하지만 중첩 삼항연산자(조건문) 문에서 zustand로 관리하는 isQuestionStarted 상태를 넣었을 경우  
[블로그](https://velog.io/@yhe228/React-Error-Rendered-fewer-hooks-than-expected-react-hooks-%EA%B7%9C%EC%B9%99)  
위와 같은 에러가 발생했다. 그런데 useState로 관리하면 에러가 발생하지 않았다.  
그래서 한 개의 상태는 어쩔 수 없이 useState를 사용했다.